### PR TITLE
Update README.md to address canvas OS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Defines visual similarity of fonts and calculates CSS properties for better simi
 ```
 npm i fonts-similarizer
 ```
+Note: If you get `node-gyp rebuild` errors try installing [Canvas Dependencies](https://www.npmjs.com/package/canvas#installation)
+
 # Usage
 
 ```js


### PR DESCRIPTION
Fixed `npm install canvas --save` for my Ubuntu installation to run Canvas install instructions first:

```
sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
```